### PR TITLE
Feature overrides

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,11 @@
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <version>1.3</version>
+    </dependency>
 
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/src/main/java/org/feature4j/Feature.java
+++ b/src/main/java/org/feature4j/Feature.java
@@ -25,7 +25,5 @@ public interface Feature<T, C extends FeaturesContext> {
 
   String name();
 
-  T value(C context);
-
-  Map<Range, T> overrides();
+  Iterable<FeatureOverride<T>> overrides();
 }

--- a/src/main/java/org/feature4j/Feature.java
+++ b/src/main/java/org/feature4j/Feature.java
@@ -25,5 +25,7 @@ public interface Feature<T, C extends FeaturesContext> {
 
   String name();
 
+  T defaultValue();
+
   Iterable<FeatureOverride<T>> overrides();
 }

--- a/src/main/java/org/feature4j/FeatureOverride.java
+++ b/src/main/java/org/feature4j/FeatureOverride.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.feature4j;
 
 

--- a/src/main/java/org/feature4j/FeatureOverride.java
+++ b/src/main/java/org/feature4j/FeatureOverride.java
@@ -1,8 +1,11 @@
 package org.feature4j;
 
+
+import com.google.common.base.Optional;
+
 /**
  * Created by dannwebster on 6/15/15.
  */
 public interface FeatureOverride<V> {
-    V extractFeatureValue(FeaturesContext ctx);
+    Optional<V> extractFeatureValue(FeaturesContext ctx);
 }

--- a/src/main/java/org/feature4j/FeatureOverride.java
+++ b/src/main/java/org/feature4j/FeatureOverride.java
@@ -1,0 +1,8 @@
+package org.feature4j;
+
+/**
+ * Created by dannwebster on 6/15/15.
+ */
+public interface FeatureOverride<V> {
+    V extractFeatureValue(FeaturesContext ctx);
+}

--- a/src/main/java/org/feature4j/FeaturesContext.java
+++ b/src/main/java/org/feature4j/FeaturesContext.java
@@ -1,6 +1,5 @@
 package org.feature4j;
 
 public interface FeaturesContext {
-
   int getBucketId();
 }

--- a/src/main/java/org/feature4j/FeaturesContext.java
+++ b/src/main/java/org/feature4j/FeaturesContext.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.feature4j;
 
 public interface FeaturesContext {

--- a/src/main/java/org/feature4j/MatcherFeatureOverride.java
+++ b/src/main/java/org/feature4j/MatcherFeatureOverride.java
@@ -1,7 +1,41 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.feature4j;
 
-/**
- * Created by dannwebster on 6/15/15.
- */
-public class MatcherFeatureOverride {
+import com.google.common.base.Optional;
+import org.hamcrest.Matcher;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class MatcherFeatureOverride<V> implements FeatureOverride<V> {
+
+  private final Matcher matcher;
+  private final V overrideValue;
+
+  public MatcherFeatureOverride(Matcher matcher, V overrideValue) {
+    this.matcher = checkNotNull(matcher, "matcher must be set to a non-null value");
+    this.overrideValue = checkNotNull(overrideValue, "overrideValue must be set to a non-null value");
+  }
+
+  @Override
+  public Optional<V> extractFeatureValue(FeaturesContext ctx) {
+    if (matcher.matches(ctx)) {
+      return Optional.of(overrideValue);
+    } else {
+      return Optional.absent();
+    }
+  }
 }

--- a/src/main/java/org/feature4j/MatcherFeatureOverride.java
+++ b/src/main/java/org/feature4j/MatcherFeatureOverride.java
@@ -1,0 +1,7 @@
+package org.feature4j;
+
+/**
+ * Created by dannwebster on 6/15/15.
+ */
+public class MatcherFeatureOverride {
+}

--- a/src/main/java/org/feature4j/SimpleFeature.java
+++ b/src/main/java/org/feature4j/SimpleFeature.java
@@ -28,14 +28,14 @@ public class SimpleFeature<T, C extends FeaturesContext> implements Feature<T, C
 
   private final List<FeatureOverride<T>> overrides;
 
-  private final T value;
+  private final T defaultValue;
 
   private final String name;
   private final String key;
 
-  public SimpleFeature(String name, String key, T value, Iterable<FeatureOverride<T>> overrides) {
+  public SimpleFeature(String name, String key, T defaultValue, Iterable<FeatureOverride<T>> overrides) {
     this.name = name;
-    this.value = value;
+    this.defaultValue = defaultValue;
     this.key = key;
     this.overrides = ImmutableList.copyOf(firstNonNull(overrides, ImmutableList.<FeatureOverride<T>>of()));
   }
@@ -50,6 +50,10 @@ public class SimpleFeature<T, C extends FeaturesContext> implements Feature<T, C
     return name;
   }
 
+  @Override
+  public T defaultValue() {
+    return defaultValue;
+  }
 
   @Override
   public Iterable<FeatureOverride<T>> overrides() {

--- a/src/main/java/org/feature4j/SimpleFeature.java
+++ b/src/main/java/org/feature4j/SimpleFeature.java
@@ -15,27 +15,29 @@
  */
 package org.feature4j;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Range;
 
+import java.util.List;
 import java.util.Map;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 
 public class SimpleFeature<T, C extends FeaturesContext> implements Feature<T, C> {
 
-  private final Map<Range, T> overrides;
+  private final List<FeatureOverride<T>> overrides;
 
   private final T value;
 
   private final String name;
   private final String key;
 
-  public SimpleFeature(String name, String key, T value, Map<Range, T> overrides) {
+  public SimpleFeature(String name, String key, T value, Iterable<FeatureOverride<T>> overrides) {
     this.name = name;
     this.value = value;
     this.key = key;
-    this.overrides = firstNonNull(overrides, ImmutableMap.<Range, T>of());
+    this.overrides = ImmutableList.copyOf(firstNonNull(overrides, ImmutableList.<FeatureOverride<T>>of()));
   }
 
   @Override
@@ -48,18 +50,9 @@ public class SimpleFeature<T, C extends FeaturesContext> implements Feature<T, C
     return name;
   }
 
-  @Override
-  public T value(C context) {
-    for (Map.Entry<Range, T> override : overrides().entrySet()) {
-      if (override.getKey().contains(firstNonNull(context.getBucketId(), 0))) {
-        return override.getValue();
-      }
-    }
-    return value;
-  }
 
   @Override
-  public Map<Range, T> overrides() {
+  public Iterable<FeatureOverride<T>> overrides() {
     return overrides;
   }
 }

--- a/src/main/java/org/feature4j/config/BucketRangeFeatureOverrideFactory.java
+++ b/src/main/java/org/feature4j/config/BucketRangeFeatureOverrideFactory.java
@@ -1,15 +1,60 @@
 package org.feature4j.config;
 
+import com.google.common.base.Optional;
+import com.google.common.collect.Range;
+import org.feature4j.FeatureOverride;
+import org.feature4j.MatcherFeatureOverride;
+import org.hamcrest.Matcher;
+import org.hamcrest.beans.HasPropertyWithValue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+
 /**
  * Created by dannwebster on 6/15/15.
  */
-public class BucketRangeFeatureOverrideFactory {
-    private static BucketRangeFeatureOverrideFactory ourInstance = new BucketRangeFeatureOverrideFactory();
+public class BucketRangeFeatureOverrideFactory implements FeatureOverridesFactory {
+  private static final Pattern RANGE_PATTERN = Pattern.compile("^\\s*(\\d+)\\s*(,\\s*(\\d+)\\s*)?$");
 
-    public static BucketRangeFeatureOverrideFactory getInstance() {
-        return ourInstance;
+  @Override
+  public Iterable<FeatureOverride> createOverrides(FeatureConfiguration featureConfiguration) {
+    List<FeatureOverride> overrides = new ArrayList<>();
+    for (Map.Entry<String, Object> entry : featureConfiguration.getOverrides().entrySet()) {
+      Optional<Range<Integer>> range = getRange(entry.getKey());
+      if (range.isPresent()) {
+        Matcher matcher = createRangeMatcher(range.get());
+        FeatureOverride featureOverride = new MatcherFeatureOverride(matcher, entry.getValue());
+        overrides.add(featureOverride);
+      }
     }
+    return overrides;
+  }
 
-    private BucketRangeFeatureOverrideFactory() {
+  public Optional<Range<Integer>> getRange(String rangeString) {
+    Optional<Range<Integer>> optRange = Optional.absent();
+    if (rangeString != null && !rangeString.isEmpty()) {
+      java.util.regex.Matcher regexMatcher = RANGE_PATTERN.matcher(rangeString);
+      if (regexMatcher.matches()) {
+        String lower = regexMatcher.group(1);
+        String upper =  (regexMatcher.group(3) != null) ? regexMatcher.group(3) : lower;
+        Range<Integer> range = Range.closed(Integer.valueOf(lower), Integer.valueOf(upper));
+        optRange = Optional.of(range);
+      }
     }
+    return optRange;
+  }
+
+  public Matcher createRangeMatcher(Range<Integer> range) {
+    return new HasPropertyWithValue("bucketId",
+        allOf(
+            greaterThanOrEqualTo(range.lowerEndpoint()),
+            lessThanOrEqualTo(range.upperEndpoint())));
+  }
 }

--- a/src/main/java/org/feature4j/config/BucketRangeFeatureOverrideFactory.java
+++ b/src/main/java/org/feature4j/config/BucketRangeFeatureOverrideFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.feature4j.config;
 
 import com.google.common.base.Optional;
@@ -17,9 +32,6 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 
-/**
- * Created by dannwebster on 6/15/15.
- */
 public class BucketRangeFeatureOverrideFactory implements FeatureOverridesFactory {
   private static final Pattern RANGE_PATTERN = Pattern.compile("^\\s*(\\d+)\\s*(,\\s*(\\d+)\\s*)?$");
 

--- a/src/main/java/org/feature4j/config/BucketRangeFeatureOverrideFactory.java
+++ b/src/main/java/org/feature4j/config/BucketRangeFeatureOverrideFactory.java
@@ -1,0 +1,15 @@
+package org.feature4j.config;
+
+/**
+ * Created by dannwebster on 6/15/15.
+ */
+public class BucketRangeFeatureOverrideFactory {
+    private static BucketRangeFeatureOverrideFactory ourInstance = new BucketRangeFeatureOverrideFactory();
+
+    public static BucketRangeFeatureOverrideFactory getInstance() {
+        return ourInstance;
+    }
+
+    private BucketRangeFeatureOverrideFactory() {
+    }
+}

--- a/src/main/java/org/feature4j/config/CompositeFeatureOverridesFactory.java
+++ b/src/main/java/org/feature4j/config/CompositeFeatureOverridesFactory.java
@@ -1,0 +1,7 @@
+package org.feature4j.config;
+
+/**
+ * Created by dannwebster on 6/15/15.
+ */
+public class CompositeFeatureOverridesFactory {
+}

--- a/src/main/java/org/feature4j/config/CompositeFeatureOverridesFactory.java
+++ b/src/main/java/org/feature4j/config/CompositeFeatureOverridesFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.feature4j.config;
 
 import com.google.common.collect.ImmutableList;
@@ -10,9 +25,6 @@ import java.util.List;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-/**
- * Created by dannwebster on 6/15/15.
- */
 public class CompositeFeatureOverridesFactory implements FeatureOverridesFactory {
   private final Iterable<FeatureOverridesFactory> featureOverridesFactories;
 

--- a/src/main/java/org/feature4j/config/CompositeFeatureOverridesFactory.java
+++ b/src/main/java/org/feature4j/config/CompositeFeatureOverridesFactory.java
@@ -1,7 +1,43 @@
 package org.feature4j.config;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import org.feature4j.FeatureOverride;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
 /**
  * Created by dannwebster on 6/15/15.
  */
-public class CompositeFeatureOverridesFactory {
+public class CompositeFeatureOverridesFactory implements FeatureOverridesFactory {
+  private final Iterable<FeatureOverridesFactory> featureOverridesFactories;
+
+  public static CompositeFeatureOverridesFactory fromFactories(FeatureOverridesFactory... factories) {
+    return fromIterable(Arrays.asList(factories));
+  }
+
+  public static CompositeFeatureOverridesFactory fromIterable(
+      Iterable<FeatureOverridesFactory> featureOverridesFactories) {
+    return new CompositeFeatureOverridesFactory(featureOverridesFactories);
+  }
+
+  CompositeFeatureOverridesFactory(Iterable<FeatureOverridesFactory> featureOverridesFactories) {
+    this.featureOverridesFactories =
+        ImmutableList.copyOf(checkNotNull(featureOverridesFactories, "featureOverridesFactories must be non-null"));
+  }
+  @Override
+  public Iterable<FeatureOverride> createOverrides(FeatureConfiguration featureConfiguration) {
+    List<FeatureOverride> allFeatureOverrides = new ArrayList<>();
+    for (FeatureOverridesFactory factory : featureOverridesFactories) {
+      Iterable<FeatureOverride> featureOverrides = factory.createOverrides(featureConfiguration);
+      if (featureOverrides != null){
+        Iterables.addAll(allFeatureOverrides, featureOverrides);
+      }
+    }
+    return allFeatureOverrides;
+  }
 }

--- a/src/main/java/org/feature4j/config/FeatureOverridesFactory.java
+++ b/src/main/java/org/feature4j/config/FeatureOverridesFactory.java
@@ -1,0 +1,7 @@
+package org.feature4j.config;
+
+/**
+ * Created by dannwebster on 6/15/15.
+ */
+public class FeatureOverridesFactory {
+}

--- a/src/main/java/org/feature4j/config/FeatureOverridesFactory.java
+++ b/src/main/java/org/feature4j/config/FeatureOverridesFactory.java
@@ -1,10 +1,22 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.feature4j.config;
 
 import org.feature4j.FeatureOverride;
 
-/**
- * Created by dannwebster on 6/15/15.
- */
 public interface FeatureOverridesFactory {
   Iterable<FeatureOverride> createOverrides(FeatureConfiguration featureConfiguration);
 }

--- a/src/main/java/org/feature4j/config/FeatureOverridesFactory.java
+++ b/src/main/java/org/feature4j/config/FeatureOverridesFactory.java
@@ -1,7 +1,10 @@
 package org.feature4j.config;
 
+import org.feature4j.FeatureOverride;
+
 /**
  * Created by dannwebster on 6/15/15.
  */
-public class FeatureOverridesFactory {
+public interface FeatureOverridesFactory {
+  Iterable<FeatureOverride> createOverrides(FeatureConfiguration featureConfiguration);
 }

--- a/src/test/java/org/feature4j/FeatureBundleProviderImplTest.java
+++ b/src/test/java/org/feature4j/FeatureBundleProviderImplTest.java
@@ -1,5 +1,6 @@
 package org.feature4j;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Range;
@@ -8,30 +9,45 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class FeatureBundleProviderImplTest {
 
+  private final FeatureOverride<String> featureOverride = mock(FeatureOverride.class);
   private final Feature<String, FeaturesContext> feature1 = new SimpleFeature<>("1", "one", "1", null);
-  private final Feature<String, FeaturesContext>
-      feature2 =
-      new SimpleFeature<>("1", "two", "0",
-          ImmutableMap.<Range, String>of(Range.closed(1, 1), "2"));
+  private final Feature<String, FeaturesContext> feature2 = new SimpleFeature<>("1", "two", "0", ImmutableList.of(featureOverride));
   private FeatureBundleProvider featureProvider;
+
 
   @Before
   public void setUp() throws Exception {
-    featureProvider =
-        new FeatureBundleProviderImpl(ImmutableList.<Feature<?, ?>>of(feature1, feature2));
+    featureProvider = new FeatureBundleProviderImpl(ImmutableList.<Feature<?, ?>>of(feature1, feature2));
   }
 
   @Test
-  public void testGetFeatures() throws Exception {
+  public void testFeatureOverridesShouldBeIgnoredIfTheyReturnNull() throws Exception {
+    when(featureOverride.extractFeatureValue(SimpleFeaturesContext.EMPTY)).thenReturn(null);
     FeatureBundle bundle = featureProvider.getFeatures(SimpleFeaturesContext.EMPTY);
     assertEquals(2, bundle.getFeatures().size());
     assertEquals("1", bundle.get("one", String.class, null));
     assertEquals("0", bundle.get("two", String.class, null));
 
-    bundle = featureProvider.getFeatures(SimpleFeaturesContext.builder().bucketId(1).build());
-    assertEquals("2", bundle.get("two", String.class, null));
+  }
+  @Test
+  public void testFeatureOverridesShouldBeIgnoredIfTheyReturnAbsent() throws Exception {
+    when(featureOverride.extractFeatureValue(SimpleFeaturesContext.EMPTY)).thenReturn(Optional.<String>absent());
+    FeatureBundle bundle = featureProvider.getFeatures(SimpleFeaturesContext.EMPTY);
+    assertEquals(2, bundle.getFeatures().size());
+    assertEquals("1", bundle.get("one", String.class, null));
+    assertEquals("0", bundle.get("two", String.class, null));
+  }
+
+  @Test
+  public void testFeatureOverridesShouldBeUsedIfTheyReturnAValue() throws Exception {
+    when(featureOverride.extractFeatureValue(SimpleFeaturesContext.EMPTY)).thenReturn(Optional.of("OVERRIDE"));
+    FeatureBundle bundle = featureProvider.getFeatures(SimpleFeaturesContext.EMPTY);
+    assertEquals("1", bundle.get("one", String.class, null));
+    assertEquals("OVERRIDE", bundle.get("two", String.class, null));
   }
 }

--- a/src/test/java/org/feature4j/FeatureBundleProviderImplTest.java
+++ b/src/test/java/org/feature4j/FeatureBundleProviderImplTest.java
@@ -1,10 +1,22 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.feature4j;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Range;
-
 import org.junit.Before;
 import org.junit.Test;
 

--- a/src/test/java/org/feature4j/FeatureBundleTest.java
+++ b/src/test/java/org/feature4j/FeatureBundleTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.feature4j;
 
 import com.google.common.collect.ImmutableMap;

--- a/src/test/java/org/feature4j/FeatureValueHydratorTest.java
+++ b/src/test/java/org/feature4j/FeatureValueHydratorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.feature4j;
 
 import org.junit.Test;

--- a/src/test/java/org/feature4j/MatcherFeatureOverrideTest.java
+++ b/src/test/java/org/feature4j/MatcherFeatureOverrideTest.java
@@ -1,10 +1,49 @@
 package org.feature4j;
 
+import com.google.common.base.Optional;
 import junit.framework.TestCase;
+import org.hamcrest.Matcher;
+import org.junit.Test;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by dannwebster on 6/15/15.
  */
 public class MatcherFeatureOverrideTest extends TestCase {
+
+  Matcher matcher = mock(Matcher.class);
+
+  @Test
+  public void testNonMatchingFeatureShouldProvideOriginalValue() throws Exception {
+    // GIVEN
+    when(matcher.matches(any())).thenReturn(false);
+    MatcherFeatureOverride<String> subject = new MatcherFeatureOverride<String>(matcher, "OVERRIDE");
+
+    // WHEN
+    Optional<String> opt = subject.extractFeatureValue(SimpleFeaturesContext.EMPTY);
+
+    // THEN
+    assertEquals(false, opt.isPresent());
+
+
+  }
+
+  @Test
+  public void testMatchingFeatureShouldProvidOverrideValue() throws Exception {
+    // GIVEN
+    when(matcher.matches(any())).thenReturn(true);
+    MatcherFeatureOverride<String> subject = new MatcherFeatureOverride<String>(matcher, "OVERRIDE");
+
+    // WHEN
+    Optional<String> opt = subject.extractFeatureValue(SimpleFeaturesContext.EMPTY);
+
+    // THEN
+    assertEquals(true, opt.isPresent());
+    assertEquals("OVERRIDE", opt.get());
+
+  }
 
 }

--- a/src/test/java/org/feature4j/MatcherFeatureOverrideTest.java
+++ b/src/test/java/org/feature4j/MatcherFeatureOverrideTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.feature4j;
 
 import com.google.common.base.Optional;
@@ -9,9 +24,6 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-/**
- * Created by dannwebster on 6/15/15.
- */
 public class MatcherFeatureOverrideTest extends TestCase {
 
   Matcher matcher = mock(Matcher.class);

--- a/src/test/java/org/feature4j/MatcherFeatureOverrideTest.java
+++ b/src/test/java/org/feature4j/MatcherFeatureOverrideTest.java
@@ -1,0 +1,10 @@
+package org.feature4j;
+
+import junit.framework.TestCase;
+
+/**
+ * Created by dannwebster on 6/15/15.
+ */
+public class MatcherFeatureOverrideTest extends TestCase {
+
+}

--- a/src/test/java/org/feature4j/SimpleFeatureTest.java
+++ b/src/test/java/org/feature4j/SimpleFeatureTest.java
@@ -1,6 +1,8 @@
 package org.feature4j;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Range;
 
 import org.junit.Before;
@@ -9,6 +11,7 @@ import org.junit.Test;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 public class SimpleFeatureTest {
 
@@ -21,31 +24,20 @@ public class SimpleFeatureTest {
   );
 
   private SimpleFeature<String, FeaturesContext> feature;
+  private FeatureOverride<String> featureOverride;
 
   @Before
   public void setUp() throws Exception {
-    feature = new SimpleFeature<>(name, key, value, overrides);
+    featureOverride = mock(FeatureOverride.class);
+    feature = new SimpleFeature<>(name, key, value, ImmutableList.of(featureOverride));
   }
 
   @Test
   public void testBasic() {
     assertEquals(name, feature.name());
     assertEquals(key, feature.key());
+    assertEquals(value, feature.defaultValue());
+    assertEquals(1, Iterables.size(feature.overrides()));
   }
 
-  @Test
-  public void testValue() {
-    SimpleFeaturesContext context = SimpleFeaturesContext.EMPTY;
-    assertEquals(value, feature.value(context));
-
-    context = SimpleFeaturesContext.builder().bucketId(5).build();
-    assertEquals(overrideValue, feature.value(context));
-
-        /*
-         * verify empty overrides returns default value.
-         */
-    feature = new SimpleFeature<>(name, key, value, null);
-
-    assertEquals(value, feature.value(context));
-  }
 }

--- a/src/test/java/org/feature4j/SimpleFeatureTest.java
+++ b/src/test/java/org/feature4j/SimpleFeatureTest.java
@@ -1,10 +1,24 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.feature4j;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Range;
-
 import org.junit.Before;
 import org.junit.Test;
 

--- a/src/test/java/org/feature4j/SimpleFeaturesContextTest.java
+++ b/src/test/java/org/feature4j/SimpleFeaturesContextTest.java
@@ -1,11 +1,23 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.feature4j;
 
 import junit.framework.TestCase;
 import org.junit.Test;
 
-/**
- * Created by dannwebster on 6/15/15.
- */
 public class SimpleFeaturesContextTest extends TestCase {
 
   @Test

--- a/src/test/java/org/feature4j/SimpleFeaturesContextTest.java
+++ b/src/test/java/org/feature4j/SimpleFeaturesContextTest.java
@@ -1,0 +1,10 @@
+package org.feature4j;
+
+import junit.framework.TestCase;
+
+/**
+ * Created by dannwebster on 6/15/15.
+ */
+public class SimpleFeaturesContextTest extends TestCase {
+
+}

--- a/src/test/java/org/feature4j/SimpleFeaturesContextTest.java
+++ b/src/test/java/org/feature4j/SimpleFeaturesContextTest.java
@@ -1,10 +1,29 @@
 package org.feature4j;
 
 import junit.framework.TestCase;
+import org.junit.Test;
 
 /**
  * Created by dannwebster on 6/15/15.
  */
 public class SimpleFeaturesContextTest extends TestCase {
 
+  @Test
+  public void testEmptyContextShouldHaveBucket0() throws Exception {
+    // WHEN
+    FeaturesContext subject = SimpleFeaturesContext.EMPTY;
+
+    // THEN
+    assertEquals(0, subject.getBucketId());
+
+  }
+  @Test
+  public void testBuilderShouldAllowCreationOfBucketId() throws Exception {
+    // WHEN
+    FeaturesContext subject = SimpleFeaturesContext.builder().bucketId(1).build();
+
+    // THEN
+    assertEquals(1, subject.getBucketId());
+
+  }
 }

--- a/src/test/java/org/feature4j/config/BucketRangeFeatureOverrideFactoryTest.java
+++ b/src/test/java/org/feature4j/config/BucketRangeFeatureOverrideFactoryTest.java
@@ -1,0 +1,10 @@
+package org.feature4j.config;
+
+import junit.framework.TestCase;
+
+/**
+ * Created by dannwebster on 6/15/15.
+ */
+public class BucketRangeFeatureOverrideFactoryTest extends TestCase {
+
+}

--- a/src/test/java/org/feature4j/config/BucketRangeFeatureOverrideFactoryTest.java
+++ b/src/test/java/org/feature4j/config/BucketRangeFeatureOverrideFactoryTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.feature4j.config;
 
 import com.google.common.base.Optional;
@@ -6,14 +21,10 @@ import junit.framework.TestCase;
 import org.feature4j.FeaturesContext;
 import org.hamcrest.Matcher;
 import org.junit.Test;
-import org.mockito.Mockito;
 
-import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-/**
- * Created by dannwebster on 6/15/15.
- */
 public class BucketRangeFeatureOverrideFactoryTest extends TestCase {
 
   BucketRangeFeatureOverrideFactory subject = new BucketRangeFeatureOverrideFactory();

--- a/src/test/java/org/feature4j/config/BucketRangeFeatureOverrideFactoryTest.java
+++ b/src/test/java/org/feature4j/config/BucketRangeFeatureOverrideFactoryTest.java
@@ -1,10 +1,67 @@
 package org.feature4j.config;
 
+import com.google.common.base.Optional;
+import com.google.common.collect.Range;
 import junit.framework.TestCase;
+import org.feature4j.FeaturesContext;
+import org.hamcrest.Matcher;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 
 /**
  * Created by dannwebster on 6/15/15.
  */
 public class BucketRangeFeatureOverrideFactoryTest extends TestCase {
 
+  BucketRangeFeatureOverrideFactory subject = new BucketRangeFeatureOverrideFactory();
+
+  @Test
+  public void testGetRangeWithOneValueInCorrectFormatShouldReturnRange() throws Exception {
+    // When
+    Optional<Range<Integer>> range = subject.getRange("2");
+    assertEquals(true, range.isPresent());
+    assertEquals(Range.closed(2, 2), subject.getRange("2").get());
+  }
+
+  @Test
+  public void testGetRangeWithTwoValuesInCorrectFormatShouldReturnRange() throws Exception {
+    // When
+    Optional<Range<Integer>> range = subject.getRange("2,50");
+    assertEquals(true, range.isPresent());
+    assertEquals(Range.closed(2, 50), range.get());
+  }
+
+  @Test
+  public void testGetRangeOnWrongFormatsReturnsNoRange() throws Exception {
+    assertEquals(false, subject.getRange(null).isPresent());
+    assertEquals(false, subject.getRange("").isPresent());
+    assertEquals(false, subject.getRange("2,X").isPresent());
+    assertEquals(false, subject.getRange("X,2").isPresent());
+    assertEquals(false, subject.getRange("X").isPresent());
+    assertEquals(false, subject.getRange("2,3,4").isPresent());
+    assertEquals(false, subject.getRange("2,3,4").isPresent());
+  }
+
+  @Test
+  public void testRangeMatcherShouldCreateMatcherThatWillMatchFeatureContextRanges() throws Exception {
+    // GIVEN
+    FeaturesContext inContext = mock(FeaturesContext.class);
+    FeaturesContext outContext = mock(FeaturesContext.class);
+
+    when(inContext.getBucketId()).thenReturn(20);
+    when(outContext.getBucketId()).thenReturn(50);
+
+
+    // WHEN
+    Matcher matcher = subject.createRangeMatcher(Range.closed(0, 20));
+
+    // THEN
+    assertEquals(true, matcher.matches(inContext));
+    assertEquals(false, matcher.matches(outContext));
+
+
+  }
 }

--- a/src/test/java/org/feature4j/config/CompositeFeatureOverridesFactoryTest.java
+++ b/src/test/java/org/feature4j/config/CompositeFeatureOverridesFactoryTest.java
@@ -1,13 +1,30 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.feature4j.config;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import junit.framework.TestCase;
 import org.feature4j.FeatureOverride;
-import org.feature4j.MatcherFeatureOverride;
 import org.junit.Test;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by dannwebster on 6/15/15.

--- a/src/test/java/org/feature4j/config/CompositeFeatureOverridesFactoryTest.java
+++ b/src/test/java/org/feature4j/config/CompositeFeatureOverridesFactoryTest.java
@@ -1,10 +1,65 @@
 package org.feature4j.config;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import junit.framework.TestCase;
+import org.feature4j.FeatureOverride;
+import org.feature4j.MatcherFeatureOverride;
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
 
 /**
  * Created by dannwebster on 6/15/15.
  */
 public class CompositeFeatureOverridesFactoryTest extends TestCase {
+  FeatureOverridesFactory fac1 = mock(FeatureOverridesFactory.class);
+  FeatureOverridesFactory fac2 = mock(FeatureOverridesFactory.class);
+
+  CompositeFeatureOverridesFactory subject = CompositeFeatureOverridesFactory.fromFactories(fac1, fac2);
+  FeatureConfiguration config = new FeatureConfiguration();
+
+  @Test
+  public void testFactoriesThatReturnNullShouldReturnEmptyList() throws Exception {
+    // GIVEN
+    // factories that return null
+
+    // WHEN
+    Iterable<FeatureOverride> overrides = subject.createOverrides(config);
+
+    // THEN
+    assertNotNull(overrides);
+    assertEquals(0, Iterables.size(overrides));
+
+    verify(fac1, times(1)).createOverrides(config);
+    verify(fac2, times(1)).createOverrides(config);
+  }
+
+  @Test
+  public void testFactoriesThatReturnFullListsTheListsShouldBeTheUnion() throws Exception {
+    // GIVEN
+    FeatureOverride override1 = mock(FeatureOverride.class);
+    FeatureOverride override2 = mock(FeatureOverride.class);
+    FeatureOverride override3 = mock(FeatureOverride.class);
+    FeatureOverride override4 = mock(FeatureOverride.class);
+
+    when(fac1.createOverrides(config)).thenReturn(ImmutableList.of(override1, override2));
+    when(fac2.createOverrides(config)).thenReturn(ImmutableList.of(override3, override4));
+
+    // WHEN
+    Iterable<FeatureOverride> overrides = subject.createOverrides(config);
+
+    // THEN
+    assertNotNull(overrides);
+    assertEquals(4, Iterables.size(overrides));
+
+    assertEquals(override1, Iterables.get(overrides, 0));
+    assertEquals(override2, Iterables.get(overrides, 1));
+    assertEquals(override3, Iterables.get(overrides, 2));
+    assertEquals(override4, Iterables.get(overrides, 3));
+
+    verify(fac1, times(1)).createOverrides(config);
+    verify(fac2, times(1)).createOverrides(config);
+  }
 
 }

--- a/src/test/java/org/feature4j/config/CompositeFeatureOverridesFactoryTest.java
+++ b/src/test/java/org/feature4j/config/CompositeFeatureOverridesFactoryTest.java
@@ -1,0 +1,10 @@
+package org.feature4j.config;
+
+import junit.framework.TestCase;
+
+/**
+ * Created by dannwebster on 6/15/15.
+ */
+public class CompositeFeatureOverridesFactoryTest extends TestCase {
+
+}

--- a/src/test/java/org/feature4j/config/FeatureConfigurationTest.java
+++ b/src/test/java/org/feature4j/config/FeatureConfigurationTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.feature4j.config;
 
 import org.junit.Test;

--- a/src/test/java/org/feature4j/config/JSONFeatureBundleProviderFactoryTest.java
+++ b/src/test/java/org/feature4j/config/JSONFeatureBundleProviderFactoryTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.feature4j.config;
 
 import org.feature4j.FeatureBundleProvider;


### PR DESCRIPTION
Refactored the usage of FeatureOverrides by creating FeatureOverridesFactories that can read different configuration models to generate different kinds of feature overrides. This opens the way to writing your own feature override factories for things like Spel, EL, etc.
